### PR TITLE
fix: SPCS deploy workflow for CI

### DIFF
--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -43,6 +43,11 @@ jobs:
           EOF
           chmod 600 ~/.snowflake/config.toml
 
+      - name: Configure Docker credentials store
+        run: |
+          mkdir -p ~/.docker
+          echo '{}' > ~/.docker/config.json
+
       - name: Docker login to Snowflake registry
         run: snow spcs image-registry login --connection ci
 

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -43,6 +43,9 @@ jobs:
           EOF
           chmod 600 ~/.snowflake/config.toml
 
+      - name: Normalize registry URL to lowercase
+        run: echo "REGISTRY=${REGISTRY,,}" >> $GITHUB_ENV
+
       - name: Configure Docker credentials store
         run: |
           mkdir -p ~/.docker
@@ -50,10 +53,6 @@ jobs:
 
       - name: Docker login to Snowflake registry
         run: snow spcs image-registry login --connection ci
-
-      - name: Debug Docker credentials
-        run: |
-          jq '.auths | to_entries[] | {registry: .key, fields: (.value | keys), authLen: (.value.auth // "" | length), tokenLen: (.value.identitytoken // "" | length)}' ~/.docker/config.json
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Debug Docker credentials
         run: |
-          jq '{auths: (.auths // {} | keys), credsStore: .credsStore, credHelpers: .credHelpers}' ~/.docker/config.json
+          jq '.auths | to_entries[] | {registry: .key, fields: (.value | keys), authLen: (.value.auth // "" | length), tokenLen: (.value.identitytoken // "" | length)}' ~/.docker/config.json
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/workflow
     paths:
       - spcs/**
   workflow_dispatch:

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -51,6 +51,21 @@ jobs:
       - name: Docker login to Snowflake registry
         run: snow spcs image-registry login --connection ci
 
+      - name: Debug Docker credentials
+        run: |
+          python3 -c "
+import json
+with open('/home/runner/.docker/config.json') as f:
+    d = json.load(f)
+safe = {}
+for k, v in d.items():
+    if k == 'auths':
+        safe[k] = {registry: '***' for registry in v}
+    else:
+        safe[k] = v
+print(json.dumps(safe, indent=2))
+"
+
       - name: Build Docker image
         run: |
           docker build --platform linux/amd64 \

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/workflow
     paths:
       - spcs/**
   workflow_dispatch:

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -43,6 +43,10 @@ jobs:
           EOF
           chmod 600 ~/.snowflake/config.toml
 
+      # Snowflake のイメージレジストリ URL は小文字でなければならない。
+      # snow spcs image-registry login が保存する認証情報のキーは常に小文字だが、
+      # GitHub Secrets の SNOWFLAKE_ORGANIZATION / SNOWFLAKE_ACCOUNT が大文字の場合、
+      # REGISTRY が大文字になり Docker の認証情報検索が一致せず push が失敗する。
       - name: Normalize registry URL to lowercase
         run: echo "REGISTRY=${REGISTRY,,}" >> $GITHUB_ENV
 

--- a/.github/workflows/spcs-deploy.yml
+++ b/.github/workflows/spcs-deploy.yml
@@ -53,18 +53,7 @@ jobs:
 
       - name: Debug Docker credentials
         run: |
-          python3 -c "
-import json
-with open('/home/runner/.docker/config.json') as f:
-    d = json.load(f)
-safe = {}
-for k, v in d.items():
-    if k == 'auths':
-        safe[k] = {registry: '***' for registry in v}
-    else:
-        safe[k] = v
-print(json.dumps(safe, indent=2))
-"
+          jq '{auths: (.auths // {} | keys), credsStore: .credsStore, credHelpers: .credHelpers}' ~/.docker/config.json
 
       - name: Build Docker image
         run: |

--- a/docs/spcs-dlt.md
+++ b/docs/spcs-dlt.md
@@ -381,3 +381,28 @@ GRANT READ, WRITE ON IMAGE REPOSITORY dlt_demo.public.my_repo TO ROLE <CLI用ロ
 - `AUTO_SUSPEND_SECS = 300` でコンピュートプールを自動停止
 - バッチ処理なので常駐 Service ではなく **Job**（`EXECUTE JOB SERVICE`）として実行
   - Job は処理完了後にコンテナが終了するため、長時間課金が発生しない
+
+---
+
+## 今後の改善点
+
+### CI のビルドキャッシュ
+
+現在の GitHub Actions ワークフローでは Docker イメージを毎回イチから構築している。依存ライブラリが増えてビルド時間が長くなったら `docker/build-push-action` に切り替えてキャッシュを有効にすることを検討する。
+
+```yaml
+- uses: docker/setup-buildx-action@v3
+
+- uses: docker/build-push-action@v6
+  with:
+    context: ./spcs/dlt
+    platforms: linux/amd64
+    push: true
+    tags: |
+      ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ github.sha }}
+      ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+`type=gha` で GitHub Actions のキャッシュストレージにレイヤーを保存する。`pipeline.py` のみの変更であれば `pip install` レイヤーがキャッシュされるためビルドが高速になる。

--- a/docs/spcs-dlt.md
+++ b/docs/spcs-dlt.md
@@ -288,6 +288,12 @@ GRANT READ, WRITE ON IMAGE REPOSITORY dlt_demo.public.my_repo TO ROLE <CLI用ロ
 
 ### Docker・イメージ関連
 
+**CI（GitHub Actions）でのイメージ push 時にレジストリ URL は小文字でなければならない**
+- `snow spcs image-registry login` が `~/.docker/config.json` に保存する認証情報のキーは常に小文字（例: `szebenz-os44603.registry.snowflakecomputing.com`）
+- GitHub Secrets に `SNOWFLAKE_ORGANIZATION` / `SNOWFLAKE_ACCOUNT` を大文字で登録している場合、レジストリ URL が大文字になり Docker の認証情報検索でキーが一致しなくなる
+- Docker は認証情報を見つけられず Authorization ヘッダーを送らないため `UNAUTHORIZED_AUTHZ_HEADER_ABSENT` エラーが発生する
+- ワークフロー内で `echo "REGISTRY=${REGISTRY,,}" >> $GITHUB_ENV` により小文字に変換して解決できる
+
 **Apple Silicon Mac では `--platform linux/amd64` が必要**
 - 指定しないと SPCS 上で `exec format error` が発生してコンテナが起動しない
 - SPCS は `amd64` アーキテクチャのみ対応


### PR DESCRIPTION
## Summary
- `snow spcs image-registry login` が保存する認証情報キーは小文字だが、GitHub Secrets が大文字の場合にレジストリ URL が大文字になり `docker push` が `UNAUTHORIZED_AUTHZ_HEADER_ABSENT` で失敗する問題を修正
- ワークフロー内でレジストリ URL を小文字に正規化するステップを追加
- 原因をワークフローのコメントと `docs/spcs-dlt.md` に記載

## Changes
- `.github/workflows/spcs-deploy.yml`: レジストリ URL の小文字正規化、デバッグステップの削除
- `docs/spcs-dlt.md`: CI での push 時の注意点を躓きポイントに追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)