### PR TITLE
Add CI IAM role for dbt artifacts bucket via GitHub Actions OIDC

### DIFF
--- a/docs/dbt-artifacts-iam.md
+++ b/docs/dbt-artifacts-iam.md
@@ -34,11 +34,17 @@ AWSのIAM best practicesと比べると、主に2点で外れている。
   role assumeのフローに対応しているかどうか。対応していなければ、flowコード内で
   手動で`sts:AssumeRole`を呼んでboto3セッションを組み立てる実装が別途必要になり、
   素のUser直付けよりも複雑さが増す
-- CI(GitHub Actions)側については事情が異なり、OIDCフェデレーションが使えるため
-  IAM User無しでRoleだけで完結できる。既存の`terraform-pr.yml`が使っている
-  `AWS_IAM_ROLE_ARN`はまさにこのパターンなので、CI用IAM(未実装、
-  cf. [dbt-artifacts-s3-bucket.md](./dbt-artifacts-s3-bucket.md)の未決定事項)は
-  最初からRoleのみで設計するのが妥当。
+- prod/devについては上記の前提条件が未確認のため、現時点でもUser直付けのまま
+  据え置いている
+
+## CI用IAMは実装済み(Role方式)
+
+CI(GitHub Actions)側は事情が異なり、OIDCフェデレーションが使えるため
+IAM User無しでRoleだけで完結できる。既存の`terraform-pr.yml`が使っている
+`AWS_IAM_ROLE_ARN`はまさにこのパターンで、今回追加した
+`dbt-snowflake-artifacts-ci`(`terraform/aws/iam.tf`)も同様にRoleのみで実装した
+(長期アクセスキー無し)。詳細は
+[dbt-artifacts-s3-bucket.md](./dbt-artifacts-s3-bucket.md)の「CI用IAM(実装済み)」を参照。
 
 ## 現状のまま進めた理由
 

--- a/docs/dbt-artifacts-s3-bucket.md
+++ b/docs/dbt-artifacts-s3-bucket.md
@@ -73,8 +73,25 @@ AWSプロバイダの認証情報はデフォルトのAWS認証情報チェー�
 
 IAMはprod/dev用にそれぞれ専用のIAM User(`dbt-snowflake-artifacts-prod` / `dbt-snowflake-artifacts-dev`)を作成し、対応するprefix(`prod/*` / `dev/*`)のみへの`s3:ListBucket`(prefix条件付き)・`s3:GetObject`・`s3:PutObject`を許可するインラインポリシーを直接アタッチしている(専用サービスアカウントのためグループ経由にはしていない)。アクセスキーは`terraform output`(sensitive)から取得し、Prefect Secret Blockへ手動登録する想定。
 
+## CI用IAM(実装済み)
+
+認証方式はGitHub Actions OIDC + IAM Role(ドキュメント旧版でいうB案)を採用した。長期的な
+静的アクセスキーをGitHub Secretsに置かないため、prod/devのUser方式より安全。
+
+- **Role**: `dbt-snowflake-artifacts-ci`(`terraform/aws/iam.tf`)
+- **trust policy**: GitHub ActionsのOIDC(`token.actions.githubusercontent.com`。このAWS
+  アカウントには`terraform-pr.yml`が使うOIDC IDプロバイダーが既に存在するため`data`で参照し、
+  新規作成はしていない)経由で、`repo:KOHTA0405/dbt_snowflake:*`(リポジトリ単位、ブランチ/
+  イベント不問)からのみAssumeRoleWithWebIdentityを許可
+- **権限範囲**: `prod/manifest/*`のみ、`s3:GetObject` + prefix条件付き`s3:ListBucket`。
+  書き込み権限は一切持たせない(state取得専用)
+- Role ARN: `terraform output dbt_artifacts_ci_role_arn`で取得し、`dbt_snowflake`リポジトリの
+  ワークフローで`aws-actions/configure-aws-credentials`の`role-to-assume`に設定する
+
+なお`aws_iam_role`の`tags`はAWSタグ値の文字種制約(`()`, `,`, `*`などは不可)に引っかかりやすい
+ので注意(初回applyで実際にエラーになった)。
+
 ## 未決定事項(実装時に詰める)
 
-- CI用IAM(GitHub Actionsから`prod/manifest/*`をGet専用で読む用途)は後回し。対象リポジトリ(dbt_snowflake)側のOIDC対応状況を確認してから着手する
 - ノードキャッシュ(`CacheConfig`)を実際に有効化するかどうか、有効化する場合の`retries`等のパラメータ設計は[dbt_snowflake側のSlim CI設計メモ](https://github.com/KOHTA0405/dbt_snowflake/blob/main/docs/ci-cd-slim-ci-plan.md)を参照
 - ライフサイクルルールの30日は「オブジェクト作成/更新からの経過日数」で判定される(S3標準機能には「最終アクセスからの日数」による削除は無いため、ドキュメント冒頭の「アクセスが無いオブジェクト」は近似)

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -44,3 +44,75 @@ resource "aws_iam_access_key" "dbt_artifacts" {
   for_each = local.dbt_artifacts_iam
   user     = aws_iam_user.dbt_artifacts[each.key].name
 }
+
+# ============================================================
+# CI(GitHub Actions, dbt_snowflakeリポジトリ)用
+# 長期アクセスキーを持たず、OIDCフェデレーション経由でRoleをAssumeする
+# ============================================================
+
+# GitHub ActionsのOIDC IDプロバイダーはこのAWSアカウントに既に存在する
+# (terraform-pr.ymlのAWS認証で使用中、Terraform管理外で作成済み)ためdataで参照する
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "dbt_artifacts_ci_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.dbt_artifacts_ci.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "dbt_artifacts_ci" {
+  name               = local.dbt_artifacts_ci.role_name
+  assume_role_policy = data.aws_iam_policy_document.dbt_artifacts_ci_trust.json
+  tags               = merge(local.dbt_artifacts.tags, { Comment = local.dbt_artifacts_ci.comment })
+}
+
+data "aws_iam_policy_document" "dbt_artifacts_ci_access" {
+  statement {
+    sid       = "ListBucketManifestPrefix"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.dbt_artifacts.arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["${local.dbt_artifacts_ci.prefix}/*"]
+    }
+  }
+
+  statement {
+    sid     = "ReadManifestObjects"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    # prefix配下の全オブジェクトが対象のため末尾ワイルドカードは構造上必須。
+    # bucket/actionはprod/manifest/*・s3:GetObjectのみに限定済み。
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["${aws_s3_bucket.dbt_artifacts.arn}/${local.dbt_artifacts_ci.prefix}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "dbt_artifacts_ci" {
+  name   = "${local.dbt_artifacts_ci.role_name}-s3-read"
+  role   = aws_iam_role.dbt_artifacts_ci.name
+  policy = data.aws_iam_policy_document.dbt_artifacts_ci_access.json
+}

--- a/terraform/aws/locals-iam.tf
+++ b/terraform/aws/locals-iam.tf
@@ -12,4 +12,13 @@ locals {
       comment   = "local/dev execution: node cache read/write"
     }
   }
+
+  # CI(GitHub Actions, dbt_snowflakeリポジトリ)用。prod/manifest/*のみGet専用。
+  # 長期アクセスキーを持たないOIDC + IAM Role方式(cf. docs/dbt-artifacts-iam.md)
+  dbt_artifacts_ci = {
+    role_name   = "dbt-snowflake-artifacts-ci"
+    github_repo = "KOHTA0405/dbt_snowflake"
+    prefix      = "prod/manifest"
+    comment     = "CI GitHub Actions dbt_snowflake repo: prod-manifest read-only"
+  }
 }

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -25,3 +25,8 @@ output "dbt_artifacts_iam_secret_access_keys" {
   value       = { for k, v in aws_iam_access_key.dbt_artifacts : k => v.secret }
   sensitive   = true
 }
+
+output "dbt_artifacts_ci_role_arn" {
+  description = "IAM role ARN for CI (GitHub Actions, dbt_snowflake repo) to assume via OIDC for prod/manifest/* read access"
+  value       = aws_iam_role.dbt_artifacts_ci.arn
+}


### PR DESCRIPTION
## Summary
- dbt_snowflakeリポジトリのGitHub Actionsが`prod/manifest/*`をGet専用で読み取るためのIAM Role(`dbt-snowflake-artifacts-ci`)を追加
- 既存のGitHub Actions OIDC IDプロバイダー(このAWSアカウントで`terraform-pr.yml`が既に使用中)を`data`で参照し、新規作成はしていない
- trust policyは`repo:KOHTA0405/dbt_snowflake:*`(リポジトリ単位)に限定
- 長期アクセスキーを持たない構成(prod/devのIAM Userとは異なる方式)
- ドキュメント(`docs/dbt-artifacts-s3-bucket.md`, `docs/dbt-artifacts-iam.md`)を実装状況に合わせて更新

## Test plan
- [x] pre-commit(fmt/validate/tflint/tfsec)全てPass
- [x] `terraform plan`で2リソース追加(Role, Role Policy)を確認してからローカルで`apply`済み
- [x] apply後の`terraform plan`で`No changes`を確認
- [x] Role ARN(`arn:aws:iam::730335183162:role/dbt-snowflake-artifacts-ci`)を取得済み。dbt_snowflakeリポジトリ側のワークフロー実装は別途必要

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>